### PR TITLE
Fix texture search utility and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+*.egg-info/

--- a/armorpaint_livelink/utils.py
+++ b/armorpaint_livelink/utils.py
@@ -1,15 +1,38 @@
+from __future__ import annotations
 
-    textures = search_textures(path, textures)
-
-    if "ArmorPaintMtl" in bpy.data.materials:
-        reload_textures()
-        return
-
-    material = bpy.data.materials.new(name="ArmorPaintMtl")
-    material.use_nodes = True
-
-    material_output = material.node_tree.nodes.get("Material Output")
-    principled_node = material.node_tree.nodes.get("Principled BSDF")
+from pathlib import Path
+from typing import List, Optional, Sequence
 
 
-    bpy.context.object.active_material = material
+def search_textures(
+    path: Path | str, textures: Sequence[Optional[str]]
+) -> List[Optional[str]]:
+    """Search ``path`` for common PBR texture files.
+
+    The ``textures`` sequence should contain seven items corresponding to
+    ``base``, ``metal``, ``normal``, ``rough``, ``ao``, ``height`` and
+    ``emissive`` textures. If a matching texture is found in ``path`` the
+    resulting list entry is replaced with the full string path to that file.
+    """
+    path = Path(path)
+    result: List[Optional[str]] = list(textures)
+
+    suffix_map = {
+        "_base": 0,
+        "_metal": 1,
+        "_normal": 2,
+        "_rough": 3,
+        "_ao": 4,
+        "_height": 5,
+        "_emit": 6,
+    }
+
+    for file in path.iterdir():
+        if not file.is_file():
+            continue
+        for suffix, idx in suffix_map.items():
+            if file.stem.endswith(suffix):
+                result[idx] = str(file)
+                break
+
+    return result


### PR DESCRIPTION
## Summary
- implement `search_textures` to locate common PBR textures
- ignore `*.egg-info/` artifacts

## Testing
- `flake8 armorpaint_livelink/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae892c66e48332bd5405ce81e35ca9